### PR TITLE
Fix : Route & theme add to main func (#2)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.morsl_app_celina0057"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:morsl_app_celina0057/core/theme/part/elevated_button_theme.dart';
+import 'package:morsl_app_celina0057/core/theme/part/input_decoration_theme.dart';
+import 'package:morsl_app_celina0057/core/theme/theme_extension/color_scheme.dart';
 import 'package:morsl_app_celina0057/core/theme/theme_extension/text_theme.dart';
 
 class AppTheme{
   AppTheme._();
   static ThemeData lightTheme = ThemeData(
-    textTheme: AppTextTheme.lightTextTheme
+    scaffoldBackgroundColor: AppColorScheme.scaffoldBackgroundColor,
+    textTheme: AppTextTheme.lightTextTheme,
+    colorScheme: AppColorScheme.lightColorScheme,
+    inputDecorationTheme: AppInputDecorationTheme.lightInputDecorationTheme,
+    elevatedButtonTheme: AppEvaluatedButtonThemes.lightEvaluatedButtonTheme
   );
 }

--- a/lib/data/routes/route_config.dart
+++ b/lib/data/routes/route_config.dart
@@ -3,6 +3,12 @@ part of 'route_import_part.dart';
 class RouteConfig {
   GoRouter goRouter = GoRouter(
     initialLocation: RouteName.initialRoute,
-    routes: [],
+    routes: [
+      GoRoute(
+        name: RouteName.initialRoute,
+        path: RouteName.initialRoute,
+        builder: (context, state) => const SplashScreen(),
+      ),
+    ],
   );
 }

--- a/lib/data/routes/route_import_part.dart
+++ b/lib/data/routes/route_import_part.dart
@@ -3,4 +3,6 @@
 import 'package:go_router/go_router.dart';
 import 'package:morsl_app_celina0057/data/routes/route_const.dart';
 
+import '../../src/feature/splash_screen/splash_screen.dart';
+
 part 'route_config.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:morsl_app_celina0057/core/theme/app_theme.dart';
+import 'data/routes/route_import_part.dart';
 
 void main() {
   runApp(const MyApp());
+  SystemChrome.setSystemUIOverlayStyle(
+    SystemUiOverlayStyle(
+      statusBarColor: Colors.transparent,
+      systemNavigationBarColor: Colors.transparent,
+      systemNavigationBarIconBrightness: Brightness.dark,
+      statusBarIconBrightness: Brightness.dark,
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -13,13 +24,15 @@ class MyApp extends StatelessWidget {
     return ScreenUtilInit(
       designSize: Size(430, 932),
       minTextAdapt: true,
-      child: MaterialApp(
-        title: 'Morsl',
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        ),
-        home: Scaffold(),
-      ),
+      builder: (context, child) {
+        return MaterialApp.router(
+          title: 'Posse',
+          debugShowCheckedModeBanner: false,
+          theme: AppTheme.lightTheme,
+          //darkTheme: AppTheme.darkTheme,
+          routerConfig: RouteConfig().goRouter,
+        );
+      },
     );
   }
 }

--- a/lib/src/feature/splash_screen/splash_screen.dart
+++ b/lib/src/feature/splash_screen/splash_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
In the current setup, the routes and theme configuration are not properly integrated into the main function. This results in disorganized route handling and inconsistent theming in the application. To resolve this, we need to:

Integrate Routes:

Add the route configuration into the main function to ensure proper navigation.

Ensure that the routes are defined and set up correctly in the GoRouter or RouteConfig class.

Add Theme:

Integrate the theme settings into the main function to ensure a consistent design throughout the app.

Include proper AppEvaluatedButtonThemes for both light and dark modes.

Ensure that the theme is applied globally.

Steps to Resolve:

Update main.dart to include route and theme configurations.

Ensure that the GoRouter or RouteConfig is correctly initialized in the main function.

Verify that theme settings (like colors and button styles) are applied globally.

Expected Outcome:

Smooth routing functionality within the app.

Consistent theme across all screens and components.